### PR TITLE
#7 - NumberCountUp 리팩토링 , 전반적인 css 순서 수정

### DIFF
--- a/src/components/atoms/Awards.tsx
+++ b/src/components/atoms/Awards.tsx
@@ -7,7 +7,9 @@ interface AwardsProps {
 
 const AwardsDiv = styled.div<AwardsProps>`
   ${({ theme, imgUrl }) => css`
+    display: inline-block;
     height: 54px;
+    margin: 50px 39px 0px 0px;
     padding: 5px 0px 5px 62px;
     background-size: 54px 54px;
     background-image: url(${imgUrl});

--- a/src/components/atoms/NumbersCountUp.tsx
+++ b/src/components/atoms/NumbersCountUp.tsx
@@ -7,17 +7,22 @@ interface NumbersCountUpProps {
 export default function NumbersCountUp({ number }: NumbersCountUpProps) {
   const [num, setNum] = useState(0);
 
-  const intervalFunction = () => {
+  useEffect(() => {
     let start = 0;
     const end = number;
+
+    const lastSpeed = 100;
+    const midSpeed = (1000 - lastSpeed) / 45;
+    const first = 1000 / (end - 50) / 10;
+    const firstSpeed = first > 1 ? first : (1 * 1000) / end;
 
     let countingUp = setInterval(() => {
       start += 10;
       setNum(start);
-      if (start >= end - 10) {
+      if (start >= end - 50) {
         clearInterval(countingUp);
         countingUp = setInterval(() => {
-          start += 5;
+          start += 1;
           setNum(start);
           if (start >= end - 5) {
             clearInterval(countingUp);
@@ -27,14 +32,12 @@ export default function NumbersCountUp({ number }: NumbersCountUpProps) {
               if (start === end) {
                 clearInterval(countingUp);
               }
-            }, 150);
+            }, lastSpeed);
           }
-        }, 50);
+        }, midSpeed);
       }
-    }, 1200 / (end - 10));
-  };
-
-  useEffect(() => intervalFunction, []);
+    }, firstSpeed);
+  }, [number]);
 
   return <span>{num}</span>;
 }

--- a/src/components/organisms/RecordSection.tsx
+++ b/src/components/organisms/RecordSection.tsx
@@ -26,12 +26,12 @@ const BigTripleImageDiv = styled.div`
     width: 400px;
     height: 338px;
     padding-top: 280px;
-    text-align: center;
-    font-size: ${theme.fonts.size.byDate};
-    color: ${theme.fonts.color.gray700};
     background-size: 400px 338px;
     background-image: url(${require("../../assets/images/triple2x.png")});
     background-repeat: no-repeat;
+    text-align: center;
+    font-size: ${theme.fonts.size.byDate};
+    color: ${theme.fonts.color.gray700};
     opacity: 0;
     animation: ${fadeIn} 700ms ease-in-out forwards;
   `}

--- a/src/components/organisms/RecordSection.tsx
+++ b/src/components/organisms/RecordSection.tsx
@@ -1,0 +1,88 @@
+import styled, { css, keyframes } from "styled-components";
+
+import Awards from "../atoms/Awards";
+import NumbersWithUnit from "../molecules/NumbersWithUnit";
+
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const RecordSectionWrapperDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 1040px;
+  margin: 50px auto;
+`;
+
+const BigTripleImageDiv = styled.div`
+  ${({ theme }) => css`
+    width: 400px;
+    height: 338px;
+    padding-top: 280px;
+    text-align: center;
+    font-size: ${theme.fonts.size.byDate};
+    color: ${theme.fonts.color.gray700};
+    background-size: 400px 338px;
+    background-image: url(${require("../../assets/images/triple2x.png")});
+    background-repeat: no-repeat;
+    opacity: 0;
+    animation: ${fadeIn} 700ms ease-in-out forwards;
+  `}
+`;
+
+const NumbersWithUnitWrapperDiv = styled.div`
+  ${({ theme }) => css`
+    margin-bottom: 20px;
+    font-size: ${theme.fonts.size.countNumber};
+    color: ${theme.fonts.color.gray};
+    letter-spacing: -1px;
+    opacity: 0;
+    animation: ${fadeIn} 700ms ease-in-out 100ms forwards;
+  `}
+`;
+
+const AwardsWrapperDiv = styled.div`
+  opacity: 0;
+  animation: ${fadeIn} 700ms ease-in-out 200ms forwards;
+`;
+
+export default function RecordSection() {
+  return (
+    <RecordSectionWrapperDiv>
+      <BigTripleImageDiv>2021년 12월 기준</BigTripleImageDiv>
+      <div>
+        <div>
+          <NumbersWithUnitWrapperDiv>
+            <NumbersWithUnit number={700} numberUnit="만" countUnit="명" />의
+            여행자
+          </NumbersWithUnitWrapperDiv>
+          <NumbersWithUnitWrapperDiv>
+            <NumbersWithUnit number={100} numberUnit="만" countUnit="개" />의
+            여행리뷰
+          </NumbersWithUnitWrapperDiv>
+          <NumbersWithUnitWrapperDiv>
+            <NumbersWithUnit number={470} numberUnit="만" countUnit="개" />의
+            여행일정
+          </NumbersWithUnitWrapperDiv>
+        </div>
+        <AwardsWrapperDiv>
+          <Awards imgUrl={require("../../assets/images/play-store2x.png")}>
+            2018 구글 플레이스토어 <br />
+            올해의 앱 최우수상 수상
+          </Awards>
+          <Awards imgUrl={require("../../assets/images/badge-apple4x.png")}>
+            2018 애플 앱스토어 <br />
+            오늘의 여행앱 선정
+          </Awards>
+        </AwardsWrapperDiv>
+      </div>
+    </RecordSectionWrapperDiv>
+  );
+}

--- a/src/components/organisms/organism.tsx
+++ b/src/components/organisms/organism.tsx
@@ -1,3 +1,0 @@
-export function Organism() {
-  return <div>hello</div>;
-}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,3 +1,15 @@
+import styled from "styled-components";
+
+import RecordSection from "../components/organisms/RecordSection";
+
+const MainWrapperDiv = styled.div`
+  min-width: 1200px;
+`;
+
 export default function Main() {
-  return <div>hello</div>;
+  return (
+    <MainWrapperDiv>
+      <RecordSection />
+    </MainWrapperDiv>
+  );
 }


### PR DESCRIPTION
## 개요
- NumbersCountUp 리팩토링
- css 컨벤션 순서에 맞게 전반적인 css 순서 수정

## 작업사항
- NumbersCountUp 기능이 부자연스러운 부분을 수정하기 위해, 전반적인 에니메이션의 속도를 수정.
- css 컨벤션 순서에 맞추기 위해 css 순서를 수정.

## 사용방법
- 컴포넌트의 props로 number, numUnit, countUnit 세개를 부여해주면 된다.

## 기타